### PR TITLE
re #28 : Corrigindo o reconhecimento da interface Bootstrap que estav…

### DIFF
--- a/Exemplo-web/pom.xml
+++ b/Exemplo-web/pom.xml
@@ -100,7 +100,7 @@
 						<configuration>
 							<executable>npm${extensao}</executable>
 							<arguments>
-								<argument>update</argument>
+								<argument>install</argument>
 							</arguments>
 							<workingDirectory>src/main/resources/static</workingDirectory>
 						</configuration>


### PR DESCRIPTION
…a com uma referência de script configurada equivocada no pom.xml, o que fazia com que a interface ficasse 'feia' sem os css's do bootstrap